### PR TITLE
Added support for Observium web-hooks

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,7 @@ var httpInputOptions = input.HttpInputOptions{
 	K8sURL:          envGet("HTTP_IN_K8S_URL", "").(string),
 	KubeURL:         envGet("HTTP_IN_KUBE_URL", "").(string),
 	WinEventURL:     envGet("HTTP_IN_WINEVENT_URL", "").(string),
+	ObserviumEventURL:     envGet("HTTP_IN_OBSERVIUM_URL", "").(string),
 	RancherURL:      envGet("HTTP_IN_RANCHER_URL", "").(string),
 	AlertmanagerURL: envGet("HTTP_IN_ALERTMANAGER_URL", "").(string),
 	GitlabURL:       envGet("HTTP_IN_GITLAB_URL", "").(string),
@@ -494,6 +495,7 @@ func Execute() {
 			processors.Add(processor.NewAWSProcessor(&outputs, observability))
 			processors.Add(processor.NewZabbixProcessor(&outputs, observability))
 			processors.Add(processor.NewVCenterProcessor(&outputs, observability))
+			processors.Add(processor.NewObserviumEventProcessor(&outputs, observability))
 
 			inputs := common.NewInputs()
 			inputs.Add(input.NewHttpInput(httpInputOptions, processors, observability))
@@ -539,6 +541,7 @@ func Execute() {
 	flags.StringVar(&httpInputOptions.K8sURL, "http-in-k8s-url", httpInputOptions.K8sURL, "Http K8s url")
 	flags.StringVar(&httpInputOptions.KubeURL, "http-in-kube-url", httpInputOptions.KubeURL, "Http Kubernetes events url")
 	flags.StringVar(&httpInputOptions.WinEventURL, "http-in-winevent-url", httpInputOptions.WinEventURL, "Http Windows Event url")
+	flags.StringVar(&httpInputOptions.ObserviumEventURL, "http-in-observium-url", httpInputOptions.ObserviumEventURL, "Http Observium Event url")
 	flags.StringVar(&httpInputOptions.RancherURL, "http-in-rancher-url", httpInputOptions.RancherURL, "Http Rancher url")
 	flags.StringVar(&httpInputOptions.AlertmanagerURL, "http-in-alertmanager-url", httpInputOptions.AlertmanagerURL, "Http Alertmanager url")
 	flags.StringVar(&httpInputOptions.GitlabURL, "http-in-gitlab-url", httpInputOptions.GitlabURL, "Http Gitlab url")

--- a/grafana.attributes
+++ b/grafana.attributes
@@ -4,6 +4,11 @@
     {{- printf "{\"%s\":\"\",\"%s\":\"\"}" .type .channel}}
   {{- end}}
   {{- if eq .type "WinEvent"}}{{- printf "{\"%s\":\"\",\"%s\":\"\",\"%s\":\"\",\"%s\":\"\"}" .data.tags.host .data.tags.city .data.tags.mt .data.tags.provider }}{{- end}}
+
+  {{- if eq .type "ObserviumEvent"}}
+  {{- printf "{\"%s\":\"\", \"%s\":\"\", \"%s\":\"\", \"%s\":\"\" }" .type .channel .data.DEVICE_HOSTNAME .data.DEVICE_LOCATION }}
+  {{- end}}
+
   {{- if eq .type "AWSEvent"}}
     {{- printf "{\"%s\":\"\",\"%s\":\"\",\"%s\":\"\",\"%s\":\"\",\"%s\":\"\"}" .type .channel .data.source .data.region .data.account}}
   {{- end}}

--- a/grafana.message
+++ b/grafana.message
@@ -26,7 +26,9 @@
   {{- if eq .type "WinEvent"}}{{- printf "[%s]%s: %s %s" .data.tags.LevelText (upper .data.tags.host) .data.tags.EventRecordID .data.tags.Message }}{{- end}}
 
   {{- if eq .type "ObserviumEvent"}}
-    {{- printf "%s<br/>State: <b>%s</b><br/>URL: <a href=\"%s\">here</a>" .data.TITLE .data.ALERT_STATE .data.ALERT_URL }}
+    {{- if not (.data.ALERT_STATE eq "ALERT REMINDER") }}
+      {{- printf "%s<br/>State: <b>%s</b><br/>URL: <a href=\"%s\">here</a>" .data.TITLE .data.ALERT_STATE .data.ALERT_URL }}
+    {{-end}}
   {{- end}}
 
   {{- if eq .type "GitlabEvent"}}

--- a/grafana.message
+++ b/grafana.message
@@ -10,8 +10,8 @@
     {{- end}}
   {{- end}}
 {{- end}}
-{{- define "text"}}
 
+{{- define "text"}}
   {{- if eq .type "K8sEvent"}}
     {{- if not (.data.user.name | regexMatch "(system:serviceaccount:*|system:*)")}}
       {{- printf "%s\n%s / %s" (upper .data.operation) .data.kind .data.location}}
@@ -24,6 +24,10 @@
   {{- end}}
 
   {{- if eq .type "WinEvent"}}{{- printf "[%s]%s: %s %s" .data.tags.LevelText (upper .data.tags.host) .data.tags.EventRecordID .data.tags.Message }}{{- end}}
+
+  {{- if eq .type "ObserviumEvent"}}
+    {{- printf "%s<br/>State: <b>%s</b><br/>URL: <a href=\"%s\">here</a>" .data.TITLE .data.ALERT_STATE .data.ALERT_URL }}
+  {{- end}}
 
   {{- if eq .type "GitlabEvent"}}
     {{- $match := getEnv "EVENTS_GITLAB_RUNNERS"}}{{$ok := false}}
@@ -58,4 +62,5 @@
     {{- end}}
   {{- end}}
 {{- end}}
+
 {{- define "grafana-message"}}{{- if .data}}{{template "text" .}}{{end}}{{- end}}

--- a/input/http.go
+++ b/input/http.go
@@ -33,6 +33,7 @@ type HttpInputOptions struct {
 	ZabbixURL       string
 	CustomJsonURL   string
 	VCenterURL      string
+	ObserviumEventURL string
 
 	Listen        string
 	Tls           bool
@@ -208,6 +209,7 @@ func (h *HttpInput) getProcessors(_ *common.Processors, _ *common.Outputs) map[s
 	h.setProcessor(m, h.options.K8sURL, processor.K8sProcessorType())
 	h.setProcessor(m, h.options.KubeURL, processor.KubeProcessorType())
 	h.setProcessor(m, h.options.WinEventURL, processor.WinEventProcessorType())
+	h.setProcessor(m, h.options.ObserviumEventURL, processor.ObserviumEventProcessorType())
 	h.setProcessor(m, h.options.AlertmanagerURL, processor.AlertmanagerProcessorType())
 	h.setProcessor(m, h.options.GitlabURL, processor.GitlabProcessorType())
 	h.setProcessor(m, h.options.RancherURL, processor.RancherProcessorType())

--- a/processor/observium.go
+++ b/processor/observium.go
@@ -1,0 +1,143 @@
+package processor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/devopsext/events/common"
+	sreCommon "github.com/devopsext/sre/common"
+)
+
+type ObserviumEventProcessor struct {
+	outputs  *common.Outputs
+	tracer   sreCommon.Tracer
+	logger   sreCommon.Logger
+	requests sreCommon.Counter
+	errors   sreCommon.Counter
+}
+
+type ObserviumRequest struct {
+    Title string            `json:"TITLE"`
+    AlertState string       `json:"ALERT_STATE"`
+	AlertURL string         `json:"ALERT_URL"`
+	AlertUnixTime int64     `json:"ALERT_UNIXTIME"`
+	DeviceHostname string   `json:"DEVICE_HOSTNAME"`
+	DeviceLocation string   `json:"DEVICE_LOCATION"`
+}
+
+type ObserviumResponse struct {
+	Message string
+}
+
+func ObserviumEventProcessorType() string {
+	return "Observium"
+}
+
+func (p *ObserviumEventProcessor) EventType() string {
+	return common.AsEventType(ObserviumEventProcessorType())
+}
+
+func (p *ObserviumEventProcessor) send(span sreCommon.TracerSpan, channel string, o interface{}, t *time.Time) {
+
+	e := &common.Event{
+		Channel: channel,
+		Type:    p.EventType(),
+		Data:    o,
+	}
+	if t != nil && (*t).UnixNano() > 0 {
+		e.SetTime((*t).UTC())
+	} else {
+		e.SetTime(time.Now().UTC())
+	}
+	if span != nil {
+		e.SetSpanContext(span.GetContext())
+		e.SetLogger(p.logger)
+	}
+	p.outputs.Send(e)
+}
+
+func (p *ObserviumEventProcessor) HandleEvent(e *common.Event) error {
+
+	if e == nil {
+		p.logger.Debug("Event is not defined")
+		return nil
+	}
+	p.requests.Inc(e.Channel)
+	p.outputs.Send(e)
+	return nil
+}
+
+func (p *ObserviumEventProcessor) HandleHttpRequest(w http.ResponseWriter, r *http.Request) error {
+
+	span := p.tracer.StartChildSpan(r.Header)
+	defer span.Finish()
+
+	channel := strings.TrimLeft(r.URL.Path, "/")
+	p.requests.Inc(channel)
+
+	var body []byte
+	if r.Body != nil {
+		if data, err := ioutil.ReadAll(r.Body); err == nil {
+			body = data
+		}
+	}
+
+	if len(body) == 0 {
+		p.errors.Inc(channel)
+		err := errors.New("empty body")
+		p.logger.SpanError(span, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return err
+	}
+
+	p.logger.SpanDebug(span, "Body => %s", body)
+
+	var observiumEvent ObserviumRequest
+	if err := json.Unmarshal(body, &observiumEvent); err != nil {
+		p.errors.Inc(channel)
+		p.logger.Error("Error decoding incoming message: %s", body)
+		p.logger.SpanError(span, err)
+		http.Error(w, "Error unmarshaling message", http.StatusInternalServerError)
+		return err
+	}
+
+	t := time.Unix(observiumEvent.AlertUnixTime, 0)
+
+	p.send(span, channel, observiumEvent, &t)
+
+	response := &ObserviumResponse{
+		Message: "OK",
+	}
+
+	resp, err := json.Marshal(response)
+	if err != nil {
+		p.errors.Inc(channel)
+		p.logger.SpanError(span, "Can't encode response: %v", err)
+		http.Error(w, fmt.Sprintf("could not encode response: %v", err), http.StatusInternalServerError)
+		return err
+	}
+
+	if _, err := w.Write(resp); err != nil {
+		p.errors.Inc(channel)
+		p.logger.SpanError(span, "Can't write response: %v", err)
+		http.Error(w, fmt.Sprintf("could not write response: %v", err), http.StatusInternalServerError)
+		return err
+	}
+	return nil
+}
+
+func NewObserviumEventProcessor(outputs *common.Outputs, observability *common.Observability) *ObserviumEventProcessor {
+
+	return &ObserviumEventProcessor{
+		outputs:  outputs,
+		logger:   observability.Logs(),
+		tracer:   observability.Traces(),
+		requests: observability.Metrics().Counter("requests", "Count of all Observium processor requests", []string{"channel"}, "observium", "processor"),
+		errors:   observability.Metrics().Counter("errors", "Count of all Observium processor errors", []string{"channel"}, "observium", "processor"),
+	}
+}

--- a/test/observium.json
+++ b/test/observium.json
@@ -1,0 +1,8 @@
+{
+  "TITLE": "Om-nom-nom! Antonovka!",
+  "ALERT_STATE": "SYSLOG",
+  "ALERT_URL": "http:/whatever.url",
+  "ALERT_UNIXTIME": 99944999399,
+  "DEVICE_HOSTNAME": "localhost",
+  "DEVICE_LOCATION": "Alaska"
+}


### PR DESCRIPTION
Enables receiving web-hooks from Observium NMS and posting the contents as Grafana annotations. Alert reminders are silenced by default. 
Example web-hook JSON could be found in `test/observium.json`. 

Web-hook configuration in Observium itself should be setup like this (field names and templated variables are matched 1 to 1):
```
{
    "TITLE": "%TITLE%",
    "ALERT_STATE": "%ALERT_STATE%",
    "ALERT_URL": "%ALERT_URL%",
    "ALERT_UNIXTIME": %ALERT_UNIXTIME%,
    "DEVICE_HOSTNAME": "%DEVICE_HOSTNAME%",
    "DEVICE_LOCATION": "%DEVICE_LOCATION%"
}
```