### PR TITLE
Observium | Extended annotation template with metric values or exact …

### DIFF
--- a/grafana.message
+++ b/grafana.message
@@ -26,9 +26,9 @@
   {{- if eq .type "WinEvent"}}{{- printf "[%s]%s: %s %s" .data.tags.LevelText (upper .data.tags.host) .data.tags.EventRecordID .data.tags.Message }}{{- end}}
 
   {{- if eq .type "ObserviumEvent"}}
-    {{- if not (.data.ALERT_STATE eq "ALERT REMINDER") }}
-      {{- printf "%s<br/>State: <b>%s</b><br/>URL: <a href=\"%s\">here</a>" .data.TITLE .data.ALERT_STATE .data.ALERT_URL }}
-    {{-end}}
+    {{- if not (eq .data.ALERT_STATE "ALERT REMINDER") }}
+      {{- printf "%s<br/>State: <b>%s</b><br/>Details:<br/><code>%s</code><br/>URL: <a href=\"%s\">here</a>" .data.TITLE .data.ALERT_STATE .data.METRICS .data.ALERT_URL }}
+    {{- end }}
   {{- end}}
 
   {{- if eq .type "GitlabEvent"}}

--- a/processor/observium.go
+++ b/processor/observium.go
@@ -22,12 +22,13 @@ type ObserviumEventProcessor struct {
 }
 
 type ObserviumRequest struct {
-    Title string            `json:"TITLE"`
-    AlertState string       `json:"ALERT_STATE"`
-	AlertURL string         `json:"ALERT_URL"`
-	AlertUnixTime int64     `json:"ALERT_UNIXTIME"`
-	DeviceHostname string   `json:"DEVICE_HOSTNAME"`
-	DeviceLocation string   `json:"DEVICE_LOCATION"`
+	Title          string `json:"TITLE"`
+	AlertState     string `json:"ALERT_STATE"`
+	AlertURL       string `json:"ALERT_URL"`
+	AlertUnixTime  int64  `json:"ALERT_UNIXTIME"`
+	DeviceHostname string `json:"DEVICE_HOSTNAME"`
+	DeviceLocation string `json:"DEVICE_LOCATION"`
+	Metrics        string `json:"METRICS"`
 }
 
 type ObserviumResponse struct {

--- a/test/observium.json
+++ b/test/observium.json
@@ -2,7 +2,8 @@
   "TITLE": "Om-nom-nom! Antonovka!",
   "ALERT_STATE": "SYSLOG",
   "ALERT_URL": "http:/whatever.url",
-  "ALERT_UNIXTIME": 99944999399,
+  "ALERT_UNIXTIME": 1661869111,
   "DEVICE_HOSTNAME": "localhost",
-  "DEVICE_LOCATION": "Alaska"
+  "DEVICE_LOCATION": "Alaska",
+  "METRICS": "This the exact message from syslog or metric and value for alerts"
 }


### PR DESCRIPTION
Observium | Extended annotation template with metric values or exact syslog message which triggered notification (so we get the information about *which exactly* BGP peer went down or came back, for example).