### PR TITLE
SRE-3945: Add service impacts to Datadog alerts in Slack

### DIFF
--- a/datadog2slack.jsonata
+++ b/datadog2slack.jsonata
@@ -1,6 +1,6 @@
 {
-    "Title": datadog.event.title,
-    "Message": "*" & $fromMillis(datadog.date) & "*: " &datadog.alert.status & " <" & datadog.link & "|Datadog Monitor Link>",
+    "Title": "*" & datadog.alert.title & "*",
+    "Message": "Date: *" & $fromMillis(datadog.date, '[D01]-[M01]-[Y0001] [H01]:[m01]:[s01] [z]') & "*\nPriority: *" &datadog.alert.priority  & "*\nScope: *" &datadog.alert.scope & "*\n*<" & datadog.link & "|Link to the event>*\n*Services:*\n" & $reduce(datadog.alert.services, function($acc, $val) {$acc & '\n' & $val}),
     "ImageURL": image,
     "Channel": slack.channel,
     "ParentTS": slack.thread,

--- a/slack.message
+++ b/slack.message
@@ -139,24 +139,30 @@
       {{- $gProjectID := atoi (index (split "@" $gProjectIDRef) 0)}}
       {{- $gURL := getEnv "EVENTS_GITLAB_URL"}}
       {{- $gToken := getEnv "EVENTS_GITLAB_TOKEN"}}
-      {{- $gQuery := printf "DATADOG_TRANSITION=Triggered,DATADOG_ID=%s,SLACK_CHANNEL,SLACK_THREAD" .data.alert.id}}
-      {{- $vars := gitlabPipelineVars $gURL $gToken $gProjectID $gQuery 10 }}
-      {{- $sChannel := jsonata $vars "$[(key='SLACK_CHANNEL')].value" }}
-      {{- $sThread := jsonata $vars "$[(key='SLACK_THREAD')].value" }}
-      {{- $slack = dict "channel" $sChannel "thread" $sThread }}
-    {{- else}}
+      {{- $gQuery := printf "DATADOG_TRANSITION=Triggered,DATADOG_KEY=%s,SLACK_CHANNEL,SLACK_THREAD" .data.key}}
+      {{- $vars := gitlabPipelineVars $gURL $gToken $gProjectID $gQuery 50 }}
+      {{- if $vars}}
+        {{- $sChannel := jsonata $vars "$[(key='SLACK_CHANNEL')].value" }}
+        {{- $sThread := jsonata $vars "$[(key='SLACK_THREAD')].value" }}
+        {{- $slack = dict "channel" $sChannel "thread" $sThread }}
+        {{- $sThread := jsonata $vars "$[(key='SLACK_THREAD')].value" }}
+      {{- end}}
+    {{- end}}
+
+    {{- if not $slack}}
       {{- $slack = dict "channel" "" "thread" "" }}
     {{- end}}
 
     {{- $image := "https://via.placeholder.com/452x185.png?text=No%20chart%20image"}}
-    {{- range (list .data.snapshot .data.snapshot .data.snapshot)}}
+    {{- range (list .data.snapshot .data.snapshot .data.snapshot .data.snapshot .data.snapshot)}}
       {{- $png := printf "%s?%s" . (randAlphaNum 6) }}
-      {{- if urlWait $png 1 2 199 }}
+      {{- if urlWait $png 2 2 199 }}
         {{- $image = $png}}
         {{- break }}
       {{- end}}
-    {{- end}} 
-    {{- logInfo "Datadog image => %s" $image }}
+    {{- end}}
+    {{- logInfo "Slack => %s" (toJSON $slack) }}
+    {{- logInfo "Datadog => %s" (toJSON .data) }}
     {{- jsonata (dict "datadog" .data "image" $image "slack" $slack) "datadog2slack.jsonata"}}
   {{- end}}
 {{- end}}


### PR DESCRIPTION
This commit enriches the Datadog alert messages forwarded to Slack. Alert titles are now bolded, the date is included, as well as the alert priority and scope. There's also now a link to the specific event, and the affected services are listed. This change allows for quicker and more efficient responses to alerts. In the Datadog processor, the alert structure now includes 'Services', indicating which services are affected by the alert. The processor also now queries a Prometheus endpoint to get a list of services affected by the product specified in the alert scope.

In the Slack message template, it now extracts the channel and thread IDs from the same GitLab pipeline variables as before, but under updated identifiers. Moreover, it tries to fetch chart images by checking more snapshot URLs than before. These enrichments provide much-needed context right in the Slack message, removing the need to jump back to Datadog or GitLab for additional investigation.