### PR TITLE
Adjust VCenter input filters (still need to rework them), multi-region support for Nomad input

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,7 +103,8 @@ var pubsubInputOptions = input.PubSubInputOptions{
 var nomadInputOptions = input.NomadInputOptions{
 	Address: envGet("NOMAD_ADDRESS", "").(string),
 	Token:   envGet("NOMAD_TOKEN", "").(string),
-	Topics:  strings.Split(envGet("NOMAD_TOPICS", "Deployment,Evaluation,Job,Node").(string), ","), //Deployment,Evaluation,Allocation,Job,Node"
+	Regions: strings.Split(envGet("NOMAD_REGIONS", "").(string), ","),
+	Topics:  strings.Split(envGet("NOMAD_TOPICS", "Deployment,Evaluation,Job,Allocation,Service").(string), ","), //Deployment,Evaluation,Allocation,Job,Node"
 }
 
 var vcInputOptions = input.VCenterInputOptions{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,7 +103,6 @@ var pubsubInputOptions = input.PubSubInputOptions{
 var nomadInputOptions = input.NomadInputOptions{
 	Address: envGet("NOMAD_ADDRESS", "").(string),
 	Token:   envGet("NOMAD_TOKEN", "").(string),
-	Regions: strings.Split(envGet("NOMAD_REGIONS", "").(string), ","),
 	Topics:  strings.Split(envGet("NOMAD_TOPICS", "Deployment,Evaluation,Job,Allocation,Service").(string), ","), //Deployment,Evaluation,Allocation,Job,Node"
 }
 

--- a/input/nomad.go
+++ b/input/nomad.go
@@ -31,7 +31,11 @@ type NomadInput struct {
 func (n *NomadInput) Start(wg *sync.WaitGroup, outputs *common.Outputs) {
 
 	q := &nomad.QueryOptions{}
-	regions, _ := n.client.Regions().List()
+	regions, err := n.client.Regions().List()
+	if err != nil {
+		n.logger.Error(err)
+		return
+	}
 
 	for _, region := range regions {
 
@@ -57,6 +61,7 @@ func (n *NomadInput) Start(wg *sync.WaitGroup, outputs *common.Outputs) {
 
 			for {
 				// Use absurdly high index num to query only last events (no backlog)
+				// math.MaxUint64 doesn't work, MaxUint32 does work, but its lesser number
 				eventCh, err := stream.Stream(n.ctx, topics, 9999999999, q)
 				if err != nil {
 					n.logger.Error(err)

--- a/input/nomad.go
+++ b/input/nomad.go
@@ -16,6 +16,7 @@ type NomadInputOptions struct {
 	Address string
 	Token   string
 	Topics  []string
+	Regions []string
 }
 
 type NomadInput struct {
@@ -26,70 +27,84 @@ type NomadInput struct {
 	eventer    sreCommon.Eventer
 	logger     sreCommon.Logger
 	meter      sreCommon.Meter
-	// requests   sreCommon.Counter
-	// errors     sreCommon.Counter
 }
 
 func (n *NomadInput) Start(wg *sync.WaitGroup, outputs *common.Outputs) {
-	wg.Add(1)
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
 
-		p := n.processors.Find("NomadEvent").(*processor.NomadProcessor)
-		if p == nil {
-			n.logger.Debug("Nomad processor is not found for NomadEvent")
-			return
-		}
+	q := &nomad.QueryOptions{}
+	regions, _ := n.client.Regions().List()
 
-		n.logger.Info("Start nomad input...")
+	for _, region := range regions {
 
-		topics := make(map[nomad.Topic][]string)
-		for _, topic := range n.options.Topics {
-			topics[nomad.Topic(topic)] = []string{"*"}
-		}
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			defer wg.Done()
 
-		q := &nomad.QueryOptions{}
-
-		stream := n.client.EventStream()
-
-		for {
-			eventCh, err := stream.Stream(n.ctx, topics, 0, q)
-			if err != nil {
-				n.logger.Error(err)
-				time.Sleep(5 * time.Second)
-				continue
+			p := n.processors.Find("NomadEvent").(*processor.NomadProcessor)
+			if p == nil {
+				n.logger.Debug("Nomad processor is not found for NomadEvent")
+				return
 			}
 
-			chanOk := true
+			n.logger.Info("Start nomad input for %s region %s", n.options.Address, region)
+
+			topics := make(map[nomad.Topic][]string)
+			for _, topic := range n.options.Topics {
+				topics[nomad.Topic(topic)] = []string{"*"}
+			}
+
+			q.Region = region
+			stream := n.client.EventStream()
+
 			for {
-				select {
-				case es, ok := <-eventCh:
-					if !ok {
-						n.logger.Error("Stream channel closed, restarting")
-						chanOk = false
-						time.Sleep(2 * time.Second)
-						break
-					}
-					if es.Err != nil {
-						n.logger.Error("Stream channel return error '%v', restarting", es.Err)
-						chanOk = false
-						time.Sleep(2 * time.Second)
-						break
-					}
-					for _, ne := range es.Events {
-						err := p.ProcessEvent(ne)
-						if err != nil {
-							n.logger.Error(err)
+				// Use absurdly high index num to query only last events (no backlog)
+				eventCh, err := stream.Stream(n.ctx, topics, 9999999999, q)
+				if err != nil {
+					n.logger.Error(err)
+					time.Sleep(5 * time.Second)
+					continue
+				}
+
+				chanOk := true
+				for {
+					select {
+					case es, ok := <-eventCh:
+						if !ok {
+							n.logger.Error("Stream channel closed, restarting")
+							chanOk = false
+							time.Sleep(2 * time.Second)
+							break
+						}
+						if es.Err != nil {
+							n.logger.Error("Stream channel return error '%v', restarting", es.Err)
+							chanOk = false
+							time.Sleep(2 * time.Second)
+							break
+						}
+						for _, ne := range es.Events {
+							labels := make(map[string]string)
+							labels["nomad"] = n.options.Address
+							labels["input"] = "nomad"
+							labels["region"] = region
+
+							requests := n.meter.Counter("nomad", "requests", "Count of all nomad input requests", labels, "input")
+							errors := n.meter.Counter("nomad", "errors", "Count of all nomad input errors", labels, "input")
+							requests.Inc()
+							err := p.ProcessEvent(ne)
+							if err != nil {
+								n.logger.Error(err)
+								errors.Inc()
+							}
 						}
 					}
+					if !chanOk {
+						break
+					}
 				}
-				if !chanOk {
-					break
-				}
+				n.logger.Debug("Restart nomad input...")
 			}
-			n.logger.Debug("Restart nomad input...")
-		}
-	}(wg)
+		}(wg)
+	}
 }
 
 func NewNomadInput(options NomadInputOptions, processors *common.Processors, observability *common.Observability) *NomadInput {
@@ -116,8 +131,5 @@ func NewNomadInput(options NomadInputOptions, processors *common.Processors, obs
 		eventer:    observability.Events(),
 		logger:     observability.Logs(),
 		meter:      observability.Metrics(),
-		// this is not used anywhere - counters never increase! Check back later when Nomad is added back
-		// requests: meter.Counter("nomad", "requests", "Count of all nomad input requests", map[string]string{}, "input", "nomad"),
-		// errors:   meter.Counter("nomad", "errors", "Count of all nomad input errors", map[string]string{}, "input", "nomad"),
 	}
 }

--- a/input/nomad.go
+++ b/input/nomad.go
@@ -16,7 +16,6 @@ type NomadInputOptions struct {
 	Address string
 	Token   string
 	Topics  []string
-	Regions []string
 }
 
 type NomadInput struct {

--- a/input/vcenter.go
+++ b/input/vcenter.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -183,7 +182,7 @@ func initCheckpoint(_ context.Context, fullPath string) (*checkpoint, error) {
 		return nil, errors.Wrap(err, "could not marshal checkpoint to JSON object")
 	}
 
-	err = ioutil.WriteFile(fullPath, jsonBytes, 0600)
+	err = os.WriteFile(fullPath, jsonBytes, 0600)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not write checkpoint file")
 	}
@@ -193,7 +192,7 @@ func initCheckpoint(_ context.Context, fullPath string) (*checkpoint, error) {
 // lastCheckpoint returns the last checkpoint for the given file
 func lastCheckpoint(_ context.Context, file io.Reader) (*checkpoint, error) {
 	var cp checkpoint
-	jsonBytes, err := ioutil.ReadAll(file)
+	jsonBytes, err := io.ReadAll(file)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read checkpoint file")
 	}

--- a/output/datadog.go
+++ b/output/datadog.go
@@ -124,7 +124,8 @@ func (d *DataDogOutput) Send(event *common.Event) {
 
 		requests := d.meter.Counter("datadog", "requests", "Count of all datadog requests", labels, "output")
 		requests.Inc()
-		d.logger.Debug("DataDog message => %s%s", name, message)
+		d.logger.Debug("DataDog name => %s", name)
+		d.logger.Debug("DataDog message => %s", message)
 
 		attributes, err := d.getAttributes(jsonObject)
 		if err != nil {

--- a/processor/vcenter.go
+++ b/processor/vcenter.go
@@ -295,6 +295,7 @@ func (vce *vcenterEvent) parse(jsonByte []byte) error {
 	// skip events and return only Debug record
 	switch vce.Subject {
 	case
+		"com.vmware.vc.RestrictedAccess",
 		"esx.audit.vmfs.volume.umounted",
 		"com.vmware.vc.sms.EsxiVasaClientCertificateRegisterSuccess",
 		"HostIsolationIpPingFailedEvent",

--- a/slack.message
+++ b/slack.message
@@ -274,16 +274,45 @@
 {{- end}}
 
 {{- define "vcenter"}}
+  {{- $text := ""}}
+  {{- $print := "false"}}
+  {{- /* If subject is present and not empty */}}
   {{- if and .data.Subject (ne .data.Subject "")}}
-    {{- printf "VCenterEvent event %s\n" .data.Subject }}
+    {{- $text = printf "%s*%s %s* %s\n" $text .type .data.Subject .data.CreatedTime }}
   {{- else}}
     {{- if and .data.DebugSubject (ne .data.DebugSubject " ")}}
-      {{- printf "VCenterEvent event %s\n" .data.DebugSubject}}
+      {{- /* printf "*VCenterEvent %s*\n" .data.DebugSubject */}}
     {{- else}}
-      {{- printf "VCenterEvent event unknown\n"}}
+      {{- $print = "true"}}
+      {{- $text = printf "%s*%s unknown* %s\n" $text .type .data.CreatedTime}}
     {{- end}}
   {{- end}}
-  {{- printf "%s" .data.RAWString}}
+
+  {{- if gt (len $text) 0}}
+    {{- if and (eq .data.Subject "AlarmStatusChangedEvent") (regexMatch "(Yellow to Red|Red to Yellow)" .data.Message) (not (regexMatch "(Virtual machine CPU usage)" .data.Message))}}
+      {{- $text = printf "%s\nLocation: %v/%v/%v/%v\nMessage:%s" $text .data.DestClusterName .data.DestLocation .data.DestESXiHostName .data.VmName .data.Message}}
+    {{- else}}
+      {{- $text = printf "%s\nMessage:%s" $text .data.Message}}
+    {{- end}}
+
+    {{- if eq .data.Subject "TaskEvent"}}
+    {{- else if eq .data.Subject "VmReconfiguredEvent"}}
+    {{- else if eq .data.Subject "com.vmware.vc.sdrs.ClearDatastoreInMultipleDatacentersEvent"}}
+    {{- else if eq .data.Subject "com.vmware.vc.sdrs.StorageDrsNewRecommendationPendingEvent"}}
+    {{- else if eq .data.Subject "com.vmware.vc.sdrs.ConfiguredStorageDrsOnPodEvent"}}
+    {{- else if eq .data.Subject "HostSyncFailedEvent"}}
+    {{- else if eq .data.Subject "VmMacChangedEvent"}}
+    {{- else if eq .data.Subject "AlarmStatusChangedEvent"}}
+    {{- else if eq .data.Subject "com.vmware.cis.tagging.attach"}}
+    {{- else}}
+      {{- $print = "true"}}
+    {{- end}}
+
+    {{- if eq $print "true"}}
+      {{- printf "%s" $text}}
+    {{- end}}
+
+  {{- end}} {{- /* if and (gt (len $text) 0) */}}
 {{- end}}
 
 {{- define "cloudflare"}}


### PR DESCRIPTION
VCenter input historically had certain types events selected for processing or discarding. While its left unchanged, some changes are made to the list of events

Nomad input had its metrics brought up in line with other inputs, and received added multi-region support for event stream